### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 ModbusConfig	KEYWORD1
-Slave		KEYWORD1
+Slave	KEYWORD1
 Operation	KEYWORD1
 
 #######################################
@@ -15,7 +15,7 @@ Operation	KEYWORD1
 #######################################
 
 parseConfig	KEYWORD2
-printConfig             KEYWORD2
+printConfig	KEYWORD2
 loopModbusConfig	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords